### PR TITLE
Fix repository URL regex ("trailing slash" bug)

### DIFF
--- a/greasemonkey/github-star-history.user.js
+++ b/greasemonkey/github-star-history.user.js
@@ -13,7 +13,7 @@
 // @description:zh-TW   將明星曆史圖表添加到 GitHub 存儲庫的側邊欄
 // @author              Adam Lui
 // @namespace           https://github.com/adamlui
-// @version             2024.4.9.1
+// @version             2024.4.27
 // @license             MIT
 // @icon                https://github.githubassets.com/favicons/favicon.png
 // @compatible          chrome
@@ -373,9 +373,20 @@
         return url
     }
 
+    function getUserAndRepoOfCurrentPage() {
+        const githubUrlRegex = /github\.com\/(?<user>[\w\-]+)\/(?<repo>[\w\-._]+)\/?/
+        const currentUrl = window.location.href
+
+        const match = currentUrl.match(githubUrlRegex)
+        if (!match) {
+            throw new Error(`Invalid Github repository URL: ${currentUrl}`)
+        }
+
+        return match.groups
+    }
+
     async function insertStarHistory() {
-        const user = /github\.com\/(.*?)\//.exec(window.location)[1],
-              repo = /.*\/([^?]*)/.exec(window.location)[1]
+        const {user, repo} = getUserAndRepoOfCurrentPage()
 
         try { // to load/insert star history chart
 
@@ -415,8 +426,7 @@
     }
 
     function zoomStarHistory(imgURL) {
-        const user = /github\.com\/(.*?)\//.exec(window.location)[1],
-              repo = /.*\/(.*)/.exec(window.location)[1]
+        const {user, repo} = getUserAndRepoOfCurrentPage()
 
         // Create/stylize overlay
         const overlay = document.createElement('div')

--- a/greasemonkey/github-star-history.user.js
+++ b/greasemonkey/github-star-history.user.js
@@ -374,15 +374,15 @@
     }
 
     function getUserAndRepoOfCurrentPage() {
-        const githubUrlRegex = /github\.com\/(?<user>[\w\-]+)\/(?<repo>[\w\-._]+)\/?/
+        const githubUrlRegex = /github\.com\/(?<user>[\w-]+)\/(?<repo>[\w.-]+)\/?/
         const currentUrl = window.location.href
 
-        const match = currentUrl.match(githubUrlRegex)
-        if (!match) {
+        const groups = githubUrlRegex.exec(currentUrl)?.groups
+        if (!groups?.user || !groups?.repo) {
             throw new Error(`Invalid Github repository URL: ${currentUrl}`)
         }
 
-        return match.groups
+        return groups
     }
 
     async function insertStarHistory() {


### PR DESCRIPTION
This PR fixes the following bug:
If the current window's URL ends with a trailing slash (e.g. `https://github.com/adamlui/github-star-history/`), then the userscript will fail to parse the repository name and the user will be presented with an empty star chart.

Additionally, I've streamlined the regex code. It now uses named capturing groups, and also more-closely follows GitHub's rules for user & repository names.