### PR TITLE
fix: resolve compatibility issue with Refined GitHub (layout glitch)

### DIFF
--- a/greasemonkey/github-star-history.user.js
+++ b/greasemonkey/github-star-history.user.js
@@ -13,7 +13,7 @@
 // @description:zh-TW   將明星曆史圖表添加到 GitHub 存儲庫的側邊欄
 // @author              Adam Lui
 // @namespace           https://github.com/adamlui
-// @version             2024.10.17.17
+// @version             2024.10.25.18
 // @license             MIT
 // @icon                https://github.githubassets.com/favicons/favicon.png
 // @compatible          chrome
@@ -157,7 +157,7 @@
                 starHistoryDiv.onclick = () => zoomStarHistory(imgDataURL)
 
                 // Insert div
-                const aboutSection = document.querySelector('[class$="sidebar"] > div > div')
+                const aboutSection = document.querySelector('.about-margin > div')
                 aboutSection.insertAdjacentElement('afterend', starHistoryDiv)
                 //移动设备添加顶部按钮
                 insertBtn(imgDataURL)

--- a/greasemonkey/github-star-history.user.js
+++ b/greasemonkey/github-star-history.user.js
@@ -13,7 +13,7 @@
 // @description:zh-TW   將明星曆史圖表添加到 GitHub 存儲庫的側邊欄
 // @author              Adam Lui
 // @namespace           https://github.com/adamlui
-// @version             2024.10.25.18
+// @version             2024.10.25
 // @license             MIT
 // @icon                https://github.githubassets.com/favicons/favicon.png
 // @compatible          chrome


### PR DESCRIPTION
after enabling Refined GitHub, there is a layout glitch in github-star-history.

before fix:
![image](https://github.com/user-attachments/assets/9957742a-bf88-4d01-b792-dd43353a32bb)

after fix:
![image](https://github.com/user-attachments/assets/1d5525e5-5508-439a-9616-d330084f0b8d)
